### PR TITLE
Updating StopWatch#mark to use Process.clock_gettime(Process::CLOCK_M…

### DIFF
--- a/lib/stop_watch.rb
+++ b/lib/stop_watch.rb
@@ -20,9 +20,9 @@ module StopWatch
     # @return [Time, Array<Float>] First time returns Time start. From then on it returns `times` method result. @see #times
     def mark
       if @mark
-        times << -(@mark - (@mark = Time.now))
+        times << -(@mark - (@mark = Process.clock_gettime(Process::CLOCK_MONOTONIC)))
       else
-        @mark = Time.now
+        @mark = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
 


### PR DESCRIPTION
There are some issues using Time.now to measure elapsed time in Ruby. I highly recommend reading this article on the subject: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/

To quickly summarize, Time.now uses implementations which are subject to changes in the wall time clock and can encounter difficulties with processing leap sections. This can especially become a problem with long running stop watch instances. The current best practice is to use the OS's monotonic clock which isn't subject to any of the same issues and measures based on elapsed time since the system boot.